### PR TITLE
fix defaults being overwritten with last call options

### DIFF
--- a/src/jquery.openxtag.js
+++ b/src/jquery.openxtag.js
@@ -98,7 +98,7 @@
             options = null;
         }
 
-        var settings = $.extend(defaults, options);
+        var settings = $.extend({}, defaults, options);
         if (zoneID != null) {
             settings['zoneID'] = zoneID;
         }


### PR DESCRIPTION
Default parameters were being overwritten by last call options. This messed things up when you make more than one call to the plugin in the same page.
